### PR TITLE
Add option to ignore stateless alerts entirely

### DIFF
--- a/navargus.example.yml
+++ b/navargus.example.yml
@@ -24,6 +24,10 @@ tags:
     service: CNaaS
 
 filters:
-  # This options ensures no incidents are posted where the alert subject is on
+  # This option ensures no incidents are posted where the alert subject is on
   # maintenance
   ignore-maintenance: true
+
+  # This option controls whether stateless NAV alerts should be submitted as
+  # Argus incidents at all
+  ignore-stateless: false

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -544,6 +544,10 @@ class Configuration(dict):
         """Returns the value of the maintenance filter option"""
         return self.get("filters", {}).get("ignore-maintenance", True)
 
+    def get_ignore_stateless(self):
+        """Returns the value of the stateless alert filter option"""
+        return self.get("filters", {}).get("ignore-stateless", False)
+
 
 if __name__ == "__main__":
     main()

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -181,39 +181,41 @@ def dispatch_alert_to_argus(alert: dict):
         bool(alert.get("on_maintenance"))
         or alert.get("event_type", {}).get("id") == "maintenanceState"
     )
-    if alerthistid:
-        if _config.get_ignore_maintenance() and on_maintenance:
-            _logger.info(
-                "Not posting incident as alert subject is on maintenance: %s",
-                alert.get("message"),
-            )
-            return
-        # We don't care about most of the contents of the JSON blob we received,
-        # actually, since we can fetch what we want and more directly from the NAV
-        # database
+    if not alerthistid:
+        return
+
+    if _config.get_ignore_maintenance() and on_maintenance:
+        _logger.info(
+            "Not posting incident as alert subject is on maintenance: %s",
+            alert.get("message"),
+        )
+        return
+    # We don't care about most of the contents of the JSON blob we received,
+    # actually, since we can fetch what we want and more directly from the NAV
+    # database
+    try:
+        alerthist = AlertHistory.objects.get(pk=alerthistid)
+    except AlertHistory.DoesNotExist:
+        # Workaround for eventengine bug: Its transaction is potentially not
+        # committed yet, so we wait just a little bit:
+        time.sleep(1)
         try:
             alerthist = AlertHistory.objects.get(pk=alerthistid)
         except AlertHistory.DoesNotExist:
-            # Workaround for eventengine bug: Its transaction is potentially not
-            # committed yet, so we wait just a little bit:
-            time.sleep(1)
-            try:
-                alerthist = AlertHistory.objects.get(pk=alerthistid)
-            except AlertHistory.DoesNotExist:
-                _logger.error(
-                    "Ignoring invalid alerthist PK received from event engine: %r",
-                    alerthistid,
-                )
-                return
+            _logger.error(
+                "Ignoring invalid alerthist PK received from event engine: %r",
+                alerthistid,
+            )
+            return
 
-        state = alert.get("state")
-        if state in (STATE_START, STATE_STATELESS):
-            incident = convert_alerthistory_object_to_argus_incident(alerthist)
-            post_incident_to_argus(incident)
-        else:
-            # when resolving, the AlertHistory timestamp may not have been updated yet
-            timestamp = alert.get("time")
-            resolve_argus_incident(alerthist, timestamp)
+    state = alert.get("state")
+    if state in (STATE_START, STATE_STATELESS):
+        incident = convert_alerthistory_object_to_argus_incident(alerthist)
+        post_incident_to_argus(incident)
+    else:
+        # when resolving, the AlertHistory timestamp may not have been updated yet
+        timestamp = alert.get("time")
+        resolve_argus_incident(alerthist, timestamp)
 
 
 def convert_alerthistory_object_to_argus_incident(alert: AlertHistory) -> Incident:

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -210,6 +210,11 @@ def dispatch_alert_to_argus(alert: dict):
 
     state = alert.get("state")
     if state in (STATE_START, STATE_STATELESS):
+        if state == STATE_STATELESS and _config.get_ignore_stateless():
+            _logger.info(
+                "Ignoring stateless alert as configured to: %s", alert.get("message")
+            )
+            return
         incident = convert_alerthistory_object_to_argus_incident(alerthist)
         post_incident_to_argus(incident)
     else:


### PR DESCRIPTION
This adds the option and implements the ignore rule based on it.

Might be best to review commit-by-commit, as it contains a code cleanup / logic fix that makes the diff look bigger than necessary.


Closes #6 