### PR TITLE
Support for configuring API request timeout values in `navargus.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support for configuring API request timeout values in `navargus.yml`
+
 ## [0.6.6] - 2023-03-13
 
 ### Fixed

--- a/navargus.example.yml
+++ b/navargus.example.yml
@@ -6,6 +6,9 @@ api:
   url: https://argus.example.org/api/v1
   token: very-long-and-secret-string
 
+  # Timeout defaults to 2.0 seconds, but may be to small in some production settings
+  # timeout: 2.0
+
   # If set to true, this ensures state differences between NAV alerts and Argus
   # Incidents are synchronized before navargus begins reading new alerts from
   # stdin

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -55,7 +55,7 @@ from django.urls import reverse
 
 _logger = logging.getLogger("navargus")
 _client = None
-_config = None  # type: Configuration
+_config: "Configuration" = None
 NOT_WHITESPACE = re.compile(r"[^\s]")
 NAV_SERIES = tuple(int(i) for i in _NAV_VERSION.split(".")[:2])
 NAV_VERSION_WITH_SEVERITY = (5, 2)
@@ -356,7 +356,7 @@ def get_argus_client():
     global _client
     if not _client:
         _client = Client(
-            api_root_url=_config.get_api_url(), token=_config.get_api_token()
+            api_root_url=_config.get_api_url(), token=_config.get_api_token(), timeout=_config.get_api_timeout()
         )
     return _client
 
@@ -554,6 +554,10 @@ class Configuration(dict):
     def get_api_token(self):
         """Returns the configured Argus API access token"""
         return self.get("api", {}).get("token")
+
+    def get_api_timeout(self) -> float:
+        """Returns the configured API request timeout value"""
+        return float(self.get("api", {}).get("timeout", 2.0))
 
     def get_sync_on_startup(self):
         """Returns True if this program should always sync the Argus API on startup"""


### PR DESCRIPTION
Default timeout is too short in our production setting, because notification dispatch hasn't been made asynchronous yet.  A POST to create a new incident can take just about 2 seconds to complete, thereby failing many of these requests.