### PR TITLE
Update requirements to avoid crashing on newer Argus releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Don't crash when Argus introduces new incident attributes.
+
 ## [0.7.0] - 2023-09-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
-    "simple_rest_client==1.0.8",
     "argus-api-client>=0.4.2",
     "pyaml",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,10 @@ authors = [{name = "Morten Brekkevold", email = "morten.brekkevold@sikt.no"}]
 description = "An Argus glue service for Network Administration Visualized"
 keywords = ["api", "argus", "client"]
 license = {text = "GPLv3"}
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.9",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
-    "argus-api-client>=0.4.2",
+    "argus-api-client>=0.5.0",
     "pyaml",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This updates the `argus-api-client` requirement to a version that doesn't crash when Argus adds new incident attributes.  It also updates Python requirements to be in line with NAV itself.
