### PR TITLE
Upgrade ruff and pre-commit hooks in pre-commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat code using black v25.1.0
+326104367c174b357f3e60ce7614ef90ab0c4c77

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.egg-info
 \#*
 
+!.git-blame-ignore-revs
+
 # These directories conist of only generated files.
 /build
 /dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: mixed-line-ending

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 25.1.0
     hooks:
     -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
+    -   id: end-of-file-fixer
+    -   id: debug-statements
 -   repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The event engine will feed `navargus` a continuous stream of NAV alerts as they
 are generated. `navargus` uses these alerts to either create new incidents in
 the Argus API, or resolve existing ones as needed.
 
-Refer to the Argus server documentation to learn more about [integrating monitoring 
+Refer to the Argus server documentation to learn more about [integrating monitoring
 systems](https://argus-server.readthedocs.io/en/latest/integrating-monitoring-systems.html)
 with Argus.
 

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -356,7 +356,9 @@ def get_argus_client():
     global _client
     if not _client:
         _client = Client(
-            api_root_url=_config.get_api_url(), token=_config.get_api_token(), timeout=_config.get_api_timeout()
+            api_root_url=_config.get_api_url(),
+            token=_config.get_api_token(),
+            timeout=_config.get_api_timeout(),
         )
     return _client
 


### PR DESCRIPTION
This PR upgrades black to the newest version v25.1.0 and pre-commit hooks to the newest version v5.0.0. It also adds the pre-commit hooks `end-of-file-fixer` and `debug-statements`.