### PR TITLE
Add parent organizations of org of netbox to tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add all parent organizations of the organization of a netbox to tags.
+
 ## [0.8.2] - 2025-08-21
 
 ### Fixed

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -315,6 +315,7 @@ def build_tags_from(alert: AlertHistory) -> Generator:
         organization = alert.netbox.organization
         yield "organization", organization.id
         # Add all parent organizations as tags
+        # TODO: add caching of organization structure
         while organization := organization.parent:
             yield "organization", organization.id
     if isinstance(subject, Netbox):

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -312,7 +312,11 @@ def build_tags_from(alert: AlertHistory) -> Generator:
         yield "host", alert.netbox.sysname
         yield "room", alert.netbox.room.id
         yield "location", alert.netbox.room.location.id
-        yield "organization", alert.netbox.organization.id
+        organization = alert.netbox.organization
+        yield "organization", organization.id
+        # Add all parent organizations as tags
+        while organization := organization.parent:
+            yield "organization", organization.id
     if isinstance(subject, Netbox):
         yield "host_url", subject.get_absolute_url()
     elif isinstance(subject, Interface):


### PR DESCRIPTION
We want to change the organization of a lot of IP devices in NAV to a child-organization of the current one, but do not want to have to change all Argus filters that are filtering for `organization=parent-org`. So now all parent organizations will also be added to the tags