### PR TITLE
Raise Python floor to 3.11 and adopt setuptools_scm

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,5 @@
 326104367c174b357f3e60ce7614ef90ab0c4c77
 # Reformat codebase using ruff v0.12.4
 e4779e14de37c4071d68655389d00e5c771beb21
+# Sort imports with ruff
+bd5aed34d917403a074751eb6e76fe7e31a90721

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
@@ -8,7 +8,7 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.4
+    rev: v0.14.13
     hooks:
         # Run the linter
     -   id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- Dropped support for Python versions older than 3.11, in line with NAV.
+
 ## [0.9.0] - 2026-02-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=61.2", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,8 +41,7 @@ include-package-data = false
 where = ["src"]
 namespaces = false
 
-[tool.setuptools.dynamic]
-version = {attr = "navargus.__version__"}
+[tool.setuptools_scm]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,9 @@ output-format = "full"
 select = ["BLE001", "E4", "E7", "E9", "F", "I"]
 fixable = ["I"]
 ignore = ["E402"]
+
+[dependency-groups]
+dev = [
+    "ruff",
+    "pre-commit",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,6 @@ extend-exclude = [
 output-format = "full"
 
 [tool.ruff.lint]
-select = ["BLE001", "E4", "E7", "E9", "F"]
+select = ["BLE001", "E4", "E7", "E9", "F", "I"]
+fixable = ["I"]
 ignore = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ authors = [{name = "Morten Brekkevold", email = "morten.brekkevold@sikt.no"}]
 description = "An Argus glue service for Network Administration Visualized"
 keywords = ["api", "argus", "client"]
 license = "GPL-3.0-only"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "argus-api-client>=0.5.0",
@@ -44,6 +46,7 @@ version = {attr = "navargus.__version__"}
 
 [tool.ruff]
 line-length = 88
+target-version = "py311"
 extend-exclude = [
     ".egg-info",
 ]

--- a/src/navargus/__init__.py
+++ b/src/navargus/__init__.py
@@ -19,4 +19,9 @@
 Package definition. The main executable is contained in glue.py.
 """
 
-__version__ = "0.9.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("nav-argus-glue")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/src/navargus/feeder.py
+++ b/src/navargus/feeder.py
@@ -5,8 +5,8 @@ It serves to verify that navargus is able to identify that its input has gone aw
 so it can exit rather than fall into a tight loop.
 """
 
-import subprocess
 import os
+import subprocess
 import sys
 
 

--- a/src/navargus/glue.py
+++ b/src/navargus/glue.py
@@ -22,35 +22,31 @@ Exports events from NAV's Event Engine streaming interface into an Argus server.
 JSON parsing inspired by https://stackoverflow.com/a/58442063
 """
 
-import select
-import sys
+import argparse
+import logging
 import os
 import re
-import logging
-import argparse
+import select
+import sys
 import time
 from datetime import datetime, timedelta
-from json import JSONDecoder, JSONDecodeError
-from typing import Generator, List, Tuple, Optional
+from json import JSONDecodeError, JSONDecoder
+from typing import Generator, List, Optional, Tuple
 
 import yaml
-
+from nav.bootstrap import bootstrap_django
+from nav.models.fields import INFINITY
 from pyargus.client import Client
 from pyargus.models import Incident
 
-from nav.bootstrap import bootstrap_django
-from nav.models.fields import INFINITY
-
 bootstrap_django("navargus")
 
-from nav.models.manage import Netbox, Interface
-from nav.models.event import AlertHistory, STATE_START, STATE_STATELESS, STATE_END
-from nav.logs import init_stderr_logging
-from nav.config import open_configfile
-from nav.buildconf import VERSION as _NAV_VERSION
-
 from django.urls import reverse
-
+from nav.buildconf import VERSION as _NAV_VERSION
+from nav.config import open_configfile
+from nav.logs import init_stderr_logging
+from nav.models.event import STATE_END, STATE_START, STATE_STATELESS, AlertHistory
+from nav.models.manage import Interface, Netbox
 
 _logger = logging.getLogger("navargus")
 _client = None


### PR DESCRIPTION
## Scope and purpose

Second in the modernization series (#29 was the first). Brings the project's packaging and lint tooling in line with NAV and the sibling glue services, with no change to runtime behaviour.

The headline change is raising the supported Python floor to 3.11: NAV 5.19.0 dropped support for anything older and now tests only on 3.11 and 3.13, so this glue service — which runs inside a NAV installation — should track that. Versioning moves from a hand-maintained `__version__` string to `setuptools_scm`, deriving the version from git tags like all three sibling repos; the runtime `__version__` is now read from installed package metadata via `importlib.metadata`. Ruff gains import sorting (the `I` rule, restricted to `fixable = ["I"]` so `--fix` never rewrites anything but imports) and an explicit `target-version = "py311"`; the one-off import reflow this triggered is isolated in its own commit and recorded in `.git-blame-ignore-revs`. Finally, the pre-commit hook pins are bumped to match CI, and a minimal `dev` dependency group is added.

The `test` and `maintenance` dependency groups the sibling repos carry are intentionally deferred to the later PRs that introduce the tooling they describe (the test suite and towncrier), so each PR only declares what it actually uses.

## Contributor Checklist

* [x] Added an entry to CHANGELOG.md
* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ..." (≤50 chars, capital, no trailing punctuation)
