### PR TITLE
Adopt towncrier for changelog management

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,0 +1,24 @@
+name: Check for changelog file
+
+on:
+  pull_request:
+      # labeled/unlabeled = label is added/removed
+      # synchronize = PR's head branch was updated
+      types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  towncrier:
+    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'nonews') && !contains(github.event.pull_request.labels.*.name, 'github_actions') }}
+    runs-on: ubuntu-latest
+    name: Towncrier check
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Install towncrier
+      run: |
+        sudo apt-get install -y pipx
+        pipx install towncrier
+    - name: Check for changelog file
+      run: towncrier check --compare-with origin/master

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 !.github/
 !.git-blame-ignore-revs
+!changelog.d/.gitkeep
 
 # These directories conist of only generated files.
 /build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
     -   id: end-of-file-fixer
+        exclude: '^changelog.d/'
     -   id: debug-statements
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for
+the upcoming release can be found in
+<https://github.com/Uninett/nav-argus-glue/tree/master/changelog.d/>.
 
-### Removed
-
-- Dropped support for Python versions older than 3.11, in line with NAV.
+<!-- towncrier release notes start -->
 
 ## [0.9.0] - 2026-02-18
 

--- a/changelog.d/+drop-python-support.removed.md
+++ b/changelog.d/+drop-python-support.removed.md
@@ -1,0 +1,1 @@
+Dropped support for Python versions older than 3.11, in line with NAV.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,42 @@ dev = [
     "pre-commit",
     {include-group = "maintenance"},
 ]
+
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}] - {project_date}"
+issue_format = "[#{issue}](https://github.com/Uninett/nav-argus-glue/issues/{issue})"
+wrap = false
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,12 @@ fixable = ["I"]
 ignore = ["E402"]
 
 [dependency-groups]
+maintenance = [
+    "towncrier",
+    "uv",
+]
 dev = [
     "ruff",
     "pre-commit",
+    {include-group = "maintenance"},
 ]


### PR DESCRIPTION
## Scope and purpose

Stacked on #30.

Third in the modernization series. Adopts [towncrier](https://towncrier.readthedocs.io/) for changelog management, matching the sibling glue services: each PR carries its own changelog fragment in `changelog.d/`, and releases assemble `CHANGELOG.md` mechanically from those fragments.

Fragments use the six Keep-a-Changelog categories (security/removed/deprecated/added/changed/fixed), and a CI check requires every PR to add one (or carry the `nonews` label). The manual `## [Unreleased]` entry that #30 added for the dropped Python support is converted into the first fragment. A `maintenance` dependency group is added for release tooling; it lists `uv` — which builds and publishes these packages — rather than the `build`/`twine` the siblings still carry.

Note: the pull-request template's contributor checklist should switch from "add a CHANGELOG.md entry" to "add a towncrier fragment", but that file is introduced by #29 and isn't in this branch's history, so that one-line swap will follow once both #29 and this land on master.

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ..." (≤50 chars, capital, no trailing punctuation)
